### PR TITLE
fix: Removing golang version from ci-run-on-pr

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -3,10 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-env:
-  # Golang version to use across CI steps
-  GOLANG_VERSION: '1.23' # As we have go toolchain 1.23 specified in go.mod
-
 permissions:
   contents: read
 
@@ -40,8 +36,6 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.0.0
       - name: Setup Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
       - name: Download all Go modules
         run: |
           go mod download
@@ -64,8 +58,6 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.0.0
       - name: Setup Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
@@ -82,8 +74,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
       - name: update to docker-compose v2
         run: |
           sudo apt-get install -y curl
@@ -111,8 +101,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
       - name: update to docker-compose v2
         run: |
           sudo apt-get install -y curl


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We have GOLANG_VERSION in ci
- dependabot breaks when updating stuff that requires a newer go version

## What is the new behavior?

- We do not have GOLANG_VERSION in ci
- dependabot can create PR-s for updates without requiring manual GO_VERSION changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
