### PR TITLE
chore: Upgrading to go 1.26

### DIFF
--- a/.github/workflows/build-and-release-binaries.yml
+++ b/.github/workflows/build-and-release-binaries.yml
@@ -4,6 +4,10 @@ on:
     types:
       - published
 
+env:
+  # Golang version to use across CI steps
+  GOLANG_VERSION: '1.26' # As we have go toolchain 1.23 specified in go.mod
+
 jobs:
   binaries:
     runs-on: ubuntu-latest
@@ -15,8 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Setup Golang
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Download cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@v2

--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Golang version to use across CI steps
+  GOLANG_VERSION: '1.26' # As we have go toolchain 1.23 specified in go.mod
+
 jobs:
   codechanges:
     if: ${{ github.event.pull_request.draft == false }}
@@ -35,7 +39,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.0.0
       - name: Setup Golang
-        uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d # v5.0.2
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+          check-latest: true
       - name: Download all Go modules
         run: |
           go mod download
@@ -57,7 +64,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.0.0
       - name: Setup Golang
-        uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d # v5.0.2
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -73,7 +82,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
       - name: Setup Golang
-        uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d # v5.0.2
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: update to docker-compose v2
         run: |
           sudo apt-get install -y curl
@@ -100,7 +111,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
       - name: Setup Golang
-        uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d # v5.0.2
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: update to docker-compose v2
         run: |
           sudo apt-get install -y curl

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pgvillage-tools/pgfga
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.12


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Building with 1.24
- pipeline not working with latest coverage action

## What is the new behavior?

- Building with 1.26
- pipeline working with latest coverage action

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language version from 1.24 to 1.26 across build configuration and CI/CD pipelines, ensuring consistency across all development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->